### PR TITLE
Replace Vundle by vim-plug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
-*.swp # ahh, the ironies...
+# vim-plug is managed by the install script
+autoload/plug.vim
 
-bundle/
+# This is where vim-plug stores stuff
+plugged/
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "bundle/Vundle.vim"]
-	path = bundle/Vundle.vim
-	url = https://github.com/gmarik/Vundle.vim.git

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,9 @@
+# vimrc installation script for Windows PowerShell
+
+# Download vim-plug
+md ~\vimfiles\autoload
+$uri = 'https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
+(New-Object Net.WebClient).DownloadFile($uri, $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("~\vimfiles\autoload\plug.vim"))
+
+# Install plugins
+vim +PlugInstall +qall

--- a/install.sh
+++ b/install.sh
@@ -1,17 +1,18 @@
 #!/bin/sh
 # vimrc install script
 
-# pring a color message.
-colormsg() { tput setaf $1; echo $2; tput sgr0; }
+# Backup old setup
+[ -f ~/.vimrc ] && mv -f ~/.vimrc ~/.vimrc.bak
+[ -f ~/.gvimrc ] && mv -f ~/.gvimrc ~/.gvimrc.bak
 
-colormsg 2 "Geting vundle..."
-git submodule update --init
+# Clone and install configuration
+curl -fLo ~/.vim/autoload/plug.vim --create-dirs \
+    https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 
-colormsg 2 "Symlinking vim..."
-ln -s $PWD/vimrc ~/.vimrc
-ln -s $PWD/gvimrc ~/.gvimrc
+# Setting up symlinks.
+ln -s ~/.vim/vimrc ~/.vimrc
+ln -s ~/.vim/gvimrc ~/.gvimrc
 
-colormsg 2 "Fetching vundles..."
-vim +PluginInstall +qall
+# Install configuration
+vim +PlugInstall +qall
 
-colormsg 2 "Enjoy."

--- a/vimrc
+++ b/vimrc
@@ -10,7 +10,7 @@
 
 " TABLE OF CONTENTS:
 " 1. Generic settings
-" 2. Vundle plugins
+" 2. Vim-Plug plugins
 " 3. File settings
 " 4. Specific filetype settings
 " 5. Colors and UI
@@ -23,42 +23,33 @@ set nocompatible " disable vi compatibility mode
 set history=1000 " increase history size
 
 " =================
-" 2. VUNDLE PLUGINS
+" 2. VIM-PLUG PLUGINS
 " =================
-" Init Vundle
-filetype off " required by Vundle.
+" Init vim-plug
 if has("win32") || has("win64")
-    set rtp+=$HOME/vimfiles/bundle/Vundle.vim/
-    call vundle#begin('$USERPROFILE/vimfiles/bundle/')
+    call plug#begin('$USERPROFILE/vimfiles/plugged/')
 else
-    set rtp+=~/.vim/bundle/Vundle.vim
-    call vundle#begin()
+    call plug#begin('~/.vim/plugged/')
 end
 
-" Vundleception. Vundle actually needs to manage Vundle.
-Plugin 'gmarik/Vundle.vim'
-
 " Plug-ins
-Plugin 'scrooloose/nerdtree'                    " NERDtree
-Plugin 'tpope/vim-fugitive'                     " Fugitive
-Plugin 'majutsushi/tagbar'                      " Tagbar
-Plugin 'Valloric/YouCompleteMe'                 " YouCompleteMe
+Plug 'scrooloose/nerdtree'                    " NERDtree
+Plug 'tpope/vim-fugitive'                     " Fugitive
+Plug 'majutsushi/tagbar'                      " Tagbar
 
 " Language support
-Plugin 'wlangstroth/vim-racket'                 " Racket
-Plugin 'jQuery'                                 " jQuery
-Plugin 'tfnico/vim-gradle'                      " Gradle
+Plug 'wlangstroth/vim-racket'                 " Racket
+Plug 'jQuery'                                 " jQuery
+Plug 'tfnico/vim-gradle'                      " Gradle
 
 if has("win32") || has("win64")
-    Plugin 'PProvost/vim-ps1'                   " PowerShell
+    Plug 'PProvost/vim-ps1'                   " PowerShell
 end
 
 " Colorschemes
-Plugin 'brendonrapp/smyck-vim'                  " Smyck
+Plug 'brendonrapp/smyck-vim'                  " Smyck
 
-" Finish Vundle initialization
-call vundle#end()
-filetype plugin indent on " Restore filetype
+call plug#end()
 
 " ================
 " 3. FILE SETTINGS


### PR DESCRIPTION
vim-plug is easier to use, manage and run than Vundle and has a few features. This PR documents the process. At the moment I managed to do this on my Windows machine but I cannot merge this until I fix the install.sh script on Linux and MacOS.
