### PR TITLE
Add install scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,57 +22,61 @@ I'm proud of it.
 * **Linux, MacOS X or Windows**: On Linux and MacOS X it works out of the
   box. Windows support is experimental but it works as well. See below
   for Windows specific information.
-* **ViM 7.3 / 7.4**: My setup is known to work under ViM 7.3. However, to
-  make use of YouCompleteMe, ViM 7.4 is required as a requirement. If you
-  cannot upgrade to ViM 7.4 yet, please disable YCM.
-* **Git and Curl**: they are required to clone Vundle.vim and for installing
-  plugins through PluginInstall.
+* **ViM 7.3**: My setup should work on Vim 7.3 since every plugin I use
+  works on that version. I don't use YCM anymore since I have replaced it.
+* **Git and Curl**: they are required by vim-plug for installing plugins.
 
-### Install
+### Quick set up
 
-Clone this repository on `~/.vim`, then run the install script.
+On Linux and MacOS you can run the following one liner:
 
-    git clone git://github.com/danirod/vimrc ~/.vim
-    cd ~/.vim
-    sh install.sh
+```sh
+curl -fL https://raw.githubusercontent.com/danirod/vimrc/master/install.sh | sh
+```
 
-Please note that at the moment YouCompleteMe has extra dependencies that
-have to be compiled manually. See
-[YCM's README](https://github.com/Valloric/YouCompleteMe/blob/master/README.md)
-for more information. You can disable YCM Plugin as well if you don't plan
-on using it. I'm considering disabling it by default since, unless I'm on
-my main development machine, I don't use it and it takes a while to get it
-working.
+On Windows PowerShell you can run the following three liner:
 
-### Windows Install
+```powershell
+iex ((New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/danirod/vimrc/install-script/instal.ps1'))
+```
 
-I finally gave ViM for Windows a try and now it works on Windows too. ViM
-for Windows uses a different path for vimrc given Windows limitations:
-`~/.vim` becomes `~/vimfiles`; `~/.vimrc` becomes `~/_vimrc` and 
-`~/.gvimrc` becomes `~/_gvimrc`.
+Should you trust these scripts? It is up to you. I somehow got to trust my
+own scripts. If you just want to download and play with the setup and are
+concerned about the security issues, please read the source code for
+`install.sh` or `install.ps1` by yourself before running the commands or
+run the install process manually.
 
-Install Git and Curl. They must be loaded in your PATH because Vundle needs
-them to install the plugins. Then, execute the following commands for
-cloning and installing Vim and Vundle.
+### Manual set up
 
-    > git clone git://github.com/danirod/vimrc %USERPROFILE%/vimfiles
-    > cd %USERPROFILE%/vimfiles
-    > git submodule update --init
-
-If ViM is on your PATH, you can install plugins automatically using:
-
-    > vim +PluginInstall +qall
-
-Otherwise, open ViM and manually execute `:PluginInstall` command to
-install plugins and colorschemes.
+Download or clone the project and put it on `~/.vim` on Linux and Mac or on
+`~\vimfiles` on Windows. To install the plugins, you will need to install
+`vim-plug`. Instructions are present on [his README][vim-plug-readme].
+To install the plugins, run `vim +PlugInstall +qall` after installing
+vim-plug.
 
 ## Plugins
 
-My vimrc setup is powered by [Vundle](http://github.com/gmarik/Vundle.vim).
-Vundle is an awesome plugin manager for Vim that takes care of automatically
-installing plugins, so you don't haveto care about them. You just add them
-to your vimrc file and Vundle can clone them.
+My vimrc is powered at the moment by [vim-plug][vim-plug]. It is a nice
+alternative to Vundle that I have found to be more simple yet powerful than
+Vundle.
 
-Check out vimrc to get the plugins. I used to keep a list with the plugins
-and a brief description about them, but since the list was almost always
-outdated, it is not useful anymore.
+To see which plugins do I use, read the `vimrc` file. I used to describe here
+my plugin setup, but since this list was almost always outdated, I don't do
+it anymore.
+
+## Disclaimer
+
+This is MY vimrc setup and it is opinionated and made to work how I want.
+Anyone can download and use my vimrc, but unless you and me are the same
+person, you'll probably find things that you don't want. It is OK. Use this
+vimrc as a starting point for making your own.
+
+**Under no circumstances I am responsible for any kind of damage derived from
+the use of this vimrc on your machine. If you lose files, if your Vim install
+breaks, if something explodes. My vimrc comes with no warranties. Again;
+you shouldn't play with my toys if you don't want to get hurt.** (This doesn't
+mean my vimrc will hurt you, you know, but this is legal boilerplate to cover
+my ass _in case_ something happens).
+
+[vim-plug-readme]: https://github.com/junegunn/vim-plug#installation
+[vim-plug]: https://github.com/junegunn/vim-plug

--- a/install.ps1
+++ b/install.ps1
@@ -1,5 +1,11 @@
 # vimrc install script
 
+# Check the user has Vim
+if (-Not (Get-Command git -ErrorAction SilentlyContinue -InformationAction SilentlyContinue)) {
+    echo "You need to install Git to clone the vimrc repository."
+    Exit
+}
+
 # Backup old setup (-f overwrites old backups)
 if (Test-Path ~\vimfiles) {
     if (Test-Path ~\vimfiles.bak) {
@@ -18,4 +24,10 @@ $uri = 'https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
 (New-Object Net.WebClient).DownloadFile($uri, $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("~\vimfiles\autoload\plug.vim"))
 
 # Execute install
-vim +PlugInstall +qall
+if (Get-Command vim -ErrorAction SilentlyContinue -InformationAction SilentlyContinue) {
+    vim +PlugInstall +qall
+} else {
+    echo "You don't have Vim installed at the moment."
+    echo "Please, install it, then run:"
+    echo "  vim +PlugInstall +qall"
+}

--- a/install.ps1
+++ b/install.ps1
@@ -1,9 +1,21 @@
-# vimrc installation script for Windows PowerShell
+# vimrc install script
 
-# Download vim-plug
-md ~\vimfiles\autoload
+# Backup old setup (-f overwrites old backups)
+if (Test-Path ~\vimfiles) {
+    if (Test-Path ~\vimfiles.bak) {
+        Remove-Item ~\vimfiles.bak -Recurse -Force
+    }
+    Move-Item ~\vimfiles -Destination ~\vimfiles.bak
+    $(Get-Item ~\vimfiles.bak -Force).Attributes = "Hidden"
+}
+
+# Clone and install configuration
+git clone https://github.com/danirod/vimrc $HOME\vimfiles
+$(Get-Item ~\vimfiles -Force).Attributes = "Hidden"
+echo 'Downloading vim-plug...'
+md ~\vimfiles\autoload -Force | Out-Null
 $uri = 'https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
 (New-Object Net.WebClient).DownloadFile($uri, $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("~\vimfiles\autoload\plug.vim"))
 
-# Install plugins
+# Execute install
 vim +PlugInstall +qall

--- a/install.sh
+++ b/install.sh
@@ -1,18 +1,21 @@
 #!/bin/sh
 # vimrc install script
 
-# Backup old setup
-[ -f ~/.vimrc ] && mv -f ~/.vimrc ~/.vimrc.bak
-[ -f ~/.gvimrc ] && mv -f ~/.gvimrc ~/.gvimrc.bak
+# Backup old setup (-f for overwriting old backups).
+[ -e ~/.vimrc ] && (rm -rf ~/.vimrc.bak; mv ~/.vimrc ~/.vimrc.bak)
+[ -e ~/.gvimrc ] && (rm -rf ~/.gvimrc.bak; mv ~/.gvimrc ~/.gvimrc.bak)
+[ -e ~/.vim ] && (rm -rf ~/.vim.bak; mv ~/.vim ~/.vim.bak)
 
-# Clone and install configuration
-curl -fLo ~/.vim/autoload/plug.vim --create-dirs \
+# Clone and install configuration.
+git clone https://github.com/danirod/vimrc ~/.vim
+echo 'Downloading vim-plug...'
+curl -sfLo ~/.vim/autoload/plug.vim --create-dirs \
     https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 
-# Setting up symlinks.
+# Set up symbolic links.
 ln -s ~/.vim/vimrc ~/.vimrc
 ln -s ~/.vim/gvimrc ~/.gvimrc
 
-# Install configuration
+# Execute install.
 vim +PlugInstall +qall
 

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,18 @@
 #!/bin/sh
 # vimrc install script
 
+# Check that Git is actually present
+if ! git --version >/dev/null 2>&1; then
+    echo "You need to install Git to clone the vimrc repository."
+    exit 1
+fi
+
+# Check that Curl is present too
+if ! curl --version >/dev/null 2>&1; then
+    echo "You need to install Curl to download vim-plug."
+    exit 1
+fi
+
 # Backup old setup (-f for overwriting old backups).
 [ -e ~/.vimrc ] && (rm -rf ~/.vimrc.bak; mv ~/.vimrc ~/.vimrc.bak)
 [ -e ~/.gvimrc ] && (rm -rf ~/.gvimrc.bak; mv ~/.gvimrc ~/.gvimrc.bak)
@@ -17,5 +29,11 @@ ln -s ~/.vim/vimrc ~/.vimrc
 ln -s ~/.vim/gvimrc ~/.gvimrc
 
 # Execute install.
-vim +PlugInstall +qall
+if vim --version >/dev/null 2>&1; then
+    vim +PlugInstall +qall
+else
+    echo "You don't have Vim installed at this moment."
+    echo "Please, install it, then run:"
+    echo "  vim +PlugInstall +qall"
+fi
 


### PR DESCRIPTION
This pull requests focuses on adding support for one line install scripts that can be copied into a command line (either a Bourne Shell like the ones on Linux or MacOS X, or a PowerShell like the one on Microsoft Windows).
- [x] Add a Bourne Shell (.sh) install script.
- [x] Add a Microsoft PowerShell (.ps1) install script.
- [x] Update README to reflect the new commands.
